### PR TITLE
Add HLS tag to stream URLs

### DIFF
--- a/twitchtv.js
+++ b/twitchtv.js
@@ -276,7 +276,7 @@
         page.source = "videoparams:" + showtime.JSONEncode({
             title: tit,
             sources: [{
-                url: url
+                url: 'hls:' + url
             }],
             no_subtitle_scan: true
         });
@@ -318,7 +318,7 @@
         page.source = "videoparams:" + showtime.JSONEncode({
             title: name,
             sources: [{
-                url: url
+                url: 'hls:' + url
             }],
             no_subtitle_scan: true
         });


### PR DESCRIPTION
Bypasses the stream detection phase, speeds up connecting to live streams.