### PR TITLE
Option to disable channel background overlay

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/lprot/movian-plugin-twitch",
 	"title": "TwitchTV",
 	"synopsis": "Twitch.TV: Game streaming.",
-	"version": "2.0.18",
+	"version": "2.0.19",
 	"file": "twitchtv.js",
 	"showtimeVersion": "4.8",
 	"type": "ecmascript",

--- a/twitchtv.js
+++ b/twitchtv.js
@@ -83,6 +83,9 @@ settings.createBool('debug', 'Enable debug logging', false, function(v) {
 settings.createBool('overridevidq', 'Override default video quality setting', false, function(v) {
     service.overridevidq = v;
 });
+settings.createBool('disablebg', 'Disable channel background overlay', false, function(v) {
+    service.disablebg = v;
+});
 
 var store = require('movian/store').create('favorites');
 
@@ -383,7 +386,9 @@ new page.Route(plugin.id + ":channel:(.*):(.*)", function (page, name, display_n
     var tryToSearch = true, first = true;
     var json = JSON.parse(http.request(API + '/streams/' + name, header));
     if (json.stream) {
-        page.metadata.background = json.stream.channel.video_banner;
+        if (service.disablebg == false) {
+            page.metadata.background = json.stream.channel.video_banner;
+            }
         page.metadata.backgroundAlpha = 0.3;
         page.metadata.logo = json.stream.channel.logo;
         page.appendItem("", "separator", {


### PR DESCRIPTION
Sometimes the backgrounds make it hard to read text on the channel page. This option defaults to off.