### PR TITLE
Show native resolution of live streams

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/lprot/movian-plugin-twitch",
 	"title": "TwitchTV",
 	"synopsis": "Twitch.TV: Game streaming.",
-	"version": "2.0.20",
+	"version": "2.0.21",
 	"file": "twitchtv.js",
 	"showtimeVersion": "4.8",
 	"type": "ecmascript",

--- a/twitchtv.js
+++ b/twitchtv.js
@@ -66,7 +66,7 @@ service.create(plugin.title, plugin.id + ":start", 'video', true, logo);
 settings.globalSettings(plugin.id, plugin.title, logo, plugin.synopsis);
 settings.createInfo("info", logo, plugin.synopsis);
 var videoQualities = [
-    ['0', 'chunked'], ['1', '1080p30'], ['2', '720p60'], ['3', '720p30', true], ['4', '480p60'], ['5', '480p30']
+    ['0', 'chunked', true], ['1', '1080p30'], ['2', '720p60'], ['3', '720p30'], ['4', '480p60'], ['5', '480p30']
 ];
 var defaultvidq;
 settings.createMultiOpt("videoQuality", "Video Quality", videoQualities, function(v) {
@@ -406,7 +406,8 @@ new page.Route(plugin.id + ":channel:(.*):(.*)", function (page, name, display_n
                 coloredStr('\nChannel created at: ', orange) + json.stream.channel.created_at.replace(/[T|Z]/g, ' ') +
                 coloredStr('\nChannel updated at: ', orange) + json.stream.channel.updated_at.replace(/[T|Z]/g, ' ') +
                 (json.stream.channel.views ? coloredStr('\nChannel views: ', orange) + json.stream.channel.views : '') +
-                (json.stream.channel.followers ? coloredStr('\nChannel followers: ', orange) + json.stream.channel.followers : ''))
+                (json.stream.channel.followers ? coloredStr('\nChannel followers: ', orange) + json.stream.channel.followers : '') +
+                (json.stream.video_height ? coloredStr('\nNative resolution: ', orange) + json.stream.video_height : '') + "p" + (json.stream.average_fps ? Math.round(json.stream.average_fps) : ''))
         });
         page.entries++;
     }


### PR DESCRIPTION
This patch also changes the default video quality setting back to chunked, which play properly on ps3 for most streams. The only thing that doesn't seem to play properly is 1080p60 or higher. With this patch you'll be able to see the resolution before you connect and change it if you so desire. When I see Native Resolution: 1080p60, I can set 720p60 and not have frames dropped or audio desync.